### PR TITLE
using range in fast_hough_line instead xrange

### DIFF
--- a/hough_transform.py
+++ b/hough_transform.py
@@ -77,7 +77,7 @@ def fast_hough_line(img, angle_step=1, lines_are_white=True, value_threshold=5):
     ysinthetas = np.dot(y_idxs.reshape((-1,1)), sin_theta.reshape((1,-1)))
     rhosmat = np.round(xcosthetas + ysinthetas) + diag_len
     rhosmat = rhosmat.astype(np.int16)
-    for i in xrange(num_thetas):
+    for i in range(num_thetas):
         rhos,counts = np.unique(rhosmat[:,i], return_counts=True)
         accumulator[rhos,i] = counts
     return accumulator, thetas, rhos


### PR DESCRIPTION
 xrange() of fast_hough_line function is replaced with a range() function for the sack of Python3 compatibility. there isn't xrange in Python3.
 
Hough_transform_test.py : 
...
----------------------------------------------------------------------
Ran 3 tests in 0.074s

OK
